### PR TITLE
libvirt-gconfig-domain-capabilities-os.c: fix pointer-sign issue

### DIFF
--- a/libvirt-gconfig/libvirt-gconfig-domain-capabilities-os.c
+++ b/libvirt-gconfig/libvirt-gconfig-domain-capabilities-os.c
@@ -67,7 +67,7 @@ static gboolean search_firmwares(xmlNodePtr node, gpointer opaque)
 {
     const gchar *content;
 
-    if (!g_str_equal(node->name, "enum"))
+    if (!g_str_equal((const gchar *)node->name, "enum"))
         return TRUE;
 
     content = gvir_config_xml_get_attribute_content(node, "name");


### PR DESCRIPTION
Signed-off-by: Markus Volk <f_l_k@t-online.de>

With glib-2.0  2.74.1 I encounter the following error:
#| In file included from ./poky/build-intel/tmp/work/corei7-64-poky-linux/libvirt-glib/4.0.0-r0/recipe-sysroot/usr/include/#glib-2.0/glib/galloca.h:35,
#|                  from ./poky/build-intel/tmp/work/corei7-64-poky-linux/libvirt-glib/4.0.0-r0/recipe-sysroot/usr/include/#glib-2.0/glib.h:32:
#| ./poky/build-intel/tmp/work/corei7-64-poky-linux/libvirt-glib/4.0.0-r0/recipe-sysroot/usr/include/string.h:156:32: note: #expected 'const char *' but argument is of type 'const xmlChar *' {aka 'const unsigned char *'}
#|   156 | extern int strcmp (const char *__s1, const char *__s2)
#|       |                    ~~~~~~~~~~~~^~~~
